### PR TITLE
Removed redundant content that seemed out of place.

### DIFF
--- a/app/chapters/typographic-design/gestalt-laws-in-typography.html
+++ b/app/chapters/typographic-design/gestalt-laws-in-typography.html
@@ -25,14 +25,6 @@
 
 <p>Note that the Law of Proximity does not mean that you should squeeze related content in a small container. No, free flowing whitespace is important too. Simply add noticeable, additional whitespace between two separate sections.</p>
 
-<p>Visual hierarchy can broken down into 5 different parts:</p>
-<ol>
-  <li><strong>Size &amp; Weight:</strong> Size and weight are the two easiest way to create visual hierarchy. They easily indicate what is important, and readers' eyes naturally jump to them. By simply styling those two, a sense of importance is already created.</li>
-  <li><strong>Positioning: </strong> Positioning is another way to create visual hierarchy. Here, the title and author is above the rest of the text and centered, showing its importance.</li>
-  <li><strong>Typeface:</strong> Contrasting typefaces can create a distinction between different elements and achieve visual hierarchy.</li>
-  <li><strong>Color: </strong>Setting important text in a different color is a very easy way to create visual hierarchy. However, only do so sparingly as using color everywhere causes it to lose its distinction.</li>
-</ol>
-
 <h3 id="law-of-similarity">Law of Similarity</h3>
 
 <p>The Gestalt Law of Similarity states that entities that look similar tend to be grouped together. For example, if all clickable texts are sky-blue, the audience will assume that all textual content that is sky-blue is clickable.</p>


### PR DESCRIPTION
Really enjoyed this guide, thanks for making it!

The Gestalt Laws chapter repeats some of the content from the Visual Hierarchy section. Seemed out of place and was wondering if it was a typo.

If not, please disregard.