### PR TITLE
Change whitespace to whitescreen in Font Loading example

### DIFF
--- a/app/chapters/fonts/font-loading.html
+++ b/app/chapters/fonts/font-loading.html
@@ -62,9 +62,9 @@
   <li>Style your fallback fonts to appear as close as possible to your actual fonts to minimize the effects of the <abbr>FOUT</abbr>. See <a href="http://www.ampsoft.net/webdesign-l/WindowsMacFonts.html">here</a> for a list of usable fallback fonts. Use <a href="http://ffffallback.com/">this tool</a> to easily compare your fallback font to your custom font.</li>
 </ul>
 
-<h3>Whitespace Approach</h3>
+<h3>Whitescreen Approach</h3>
 
-<p>Here is an example of using Web Font Loader with the whitespace approach:</p>
+<p>Here is an example of using Web Font Loader with the whitescreen approach:</p>
 
 <pre><code>&lt;script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"&gt;&lt;/script&gt;
 &lt;script&gt;


### PR DESCRIPTION
It's listed as whitescreen above in the list of ways to handle font loading. I suggest a change to be more consistent