### PR TITLE
Fixing typo in visual hierarchy section.

### DIFF
--- a/app/chapters/typographic-design/visual-hierarchy.html
+++ b/app/chapters/typographic-design/visual-hierarchy.html
@@ -14,7 +14,7 @@
 
 <p>Visual hierarchy can be broken down into 5 different parts:</p>
 <ol>
-  <li><strong>Size & Weight:</strong> Size and weight are the two easiest way to create visual hierarchy. They easily indicate what is important, and readers' eyes naturally jump to them. By simply styling those two, a sense of importance is already created.</li>
+  <li><strong>Size & Weight:</strong> Size and weight are the two easiest ways to create visual hierarchy. They easily indicate what is important, and readers' eyes naturally jump to them. By simply styling those two, a sense of importance is already created.</li>
   <li><strong>Positioning: </strong> Positioning is another way to create visual hierarchy. Here, the title and author is above the rest of the text and centered, showing its importance.</li>
   <li><strong>Typeface:</strong> Contrasting typefaces can create a distinction between different elements and achieve visual hierarchy.</li>
   <li><strong>Color: </strong>Setting important text in a different color is a very easy way to create visual hierarchy. However, only do so sparingly as using color everywhere causes it to lose its distinction.</li>


### PR DESCRIPTION
> Size and weight are the two easiest way to create visual hierarchy.

Fixed the `way` to be `ways`.