### PR TITLE
Fix error in example usage of link-underline mixin

### DIFF
--- a/app/chapters/web-style-guide/underlining.html
+++ b/app/chapters/web-style-guide/underlining.html
@@ -64,7 +64,7 @@
 
 /* Example usage */
 a {
-  @include link-underline(#fff, #333, #0CBF);
+  @include link-underline(#fff, #333, #0BF);
 }</code></pre>
 
 <figure>


### PR DESCRIPTION
Example usage of `link-underline` mixin is:

```
a {
  @include link-underline(#fff, #333, #0CBF);
}
```

Which is not compiles as `#0CBF` is invalid RGB color.

So I'd suggest to change the color to blue `#0BF`:

```
a {
  @include link-underline(#fff, #333, #0BF);
}
```